### PR TITLE
Clarifies Python 3 in documentation

### DIFF
--- a/doc/faq.txt
+++ b/doc/faq.txt
@@ -5,10 +5,15 @@
 ==========================
 Frequently Asked Questions
 ==========================
+
+Does Theano support Python 3?
+------------------------------
+We support both Python 2 >= 2.6 and Python 3 >= 3.3.
+
 TypeError: object of type 'TensorVariable' has no len()
 -------------------------------------------------------
 
-If you receive the following error, it is because the Python function *__len__* cannot 
+If you receive the following error, it is because the Python function *__len__* cannot
 be implemented on Theano variables:
 
 .. code-block:: python
@@ -17,7 +22,7 @@ be implemented on Theano variables:
 
 Python requires that *__len__* returns an integer, yet it cannot be done as Theano's variables are symbolic. However, `var.shape[0]` can be used as a workaround.
 
-This error message cannot be made more explicit because the relevant aspects of Python's 
+This error message cannot be made more explicit because the relevant aspects of Python's
 internals cannot be modified.
 
 
@@ -64,10 +69,10 @@ compilation but it will also use more memory because
 in a trade off between speed of compilation and memory usage.
 
 Theano flag `reoptimize_unpickled_function` controls if an unpickled theano function
-should reoptimize its graph or not. Theano users can use the standard python pickle 
-tools to save a compiled theano function. When pickling, both graph before and 
-after the optimization are saved, including shared variables. When set to True, 
-the graph is reoptimized when being unpickled. Otherwise, skip the graph optimization 
+should reoptimize its graph or not. Theano users can use the standard python pickle
+tools to save a compiled theano function. When pickling, both graph before and
+after the optimization are saved, including shared variables. When set to True,
+the graph is reoptimized when being unpickled. Otherwise, skip the graph optimization
 and use directly the optimized graph from the pickled file. After Theano 0.7,
 the default changed to False.
 
@@ -197,7 +202,7 @@ We try to list in this `wiki page <https://github.com/Theano/Theano/wiki/Related
 --------------------------------
 
 Theano offers a good amount of flexibility, but has some limitations too.
-You must answer for yourself the following question: How can my algorithm be cleverly written 
+You must answer for yourself the following question: How can my algorithm be cleverly written
 so as to make the most of what Theano can do?
 
 Here is a list of some of the known limitations:

--- a/doc/install.txt
+++ b/doc/install.txt
@@ -20,11 +20,11 @@ instructions below for detailed installation steps):
         We develop mainly on 64-bit Linux machines. other architectures are
         not well-tested.
 
-    Python_ >= 2.6
+    Python_ 2 >= 2.6 or Python_ 3 >= 3.3
         The development package (``python-dev`` or ``python-devel``
         on most Linux distributions) is recommended (see just below).
         Python 2.4 was supported up to and including the release 0.6.
-        Python 3 is supported via 2to3 only, starting from 3.3.
+        Python 3 is supported past the 3.3 release.
 
     ``g++``, ``python-dev``
         Not technically required but *highly* recommended, in order to compile
@@ -147,7 +147,13 @@ by typing
 
     pip install Theano
 
-You may need to add ``sudo``  before this command to install into your
+This should work under Python 2 or Python 3. To test, run
+
+.. code-block:: bash
+
+    nosetests theano
+
+You may need to add ``sudo``  before the ``pip`` command to install into your
 system's ``site-packages`` directory. If you do not have administrator access
 to your machine, you can install Theano locally (to ~/.local) using
 
@@ -226,7 +232,7 @@ Bleeding-edge install instructions
 If you are a developer of Theano, then check out the :ref:`dev_start_guide`.
 
 If you want the bleeding-edge without developing the code you can use pip for
-this with the command line below. Note that it will also try to install Theano's dependencies 
+this with the command line below. Note that it will also try to install Theano's dependencies
 (like NumPy and SciPy), but not upgrade them. If you wish to upgrade them,
 remove the ``--no-deps`` switch to it, but go see a previous warning before doing this.
 
@@ -254,11 +260,6 @@ From here, the easiest way to get started is (this requires setuptools_ or distr
 
     cd Theano
     python setup.py develop
-
-.. note::
-
-   "python setup.py develop ..." does not work on Python 3 as it does not call
-   the converter from Python 2 code to Python 3 code.
 
 This will install a ``.pth`` file in your ``site-packages`` directory that
 tells Python where to look for your Theano installation (i.e. in the

--- a/doc/introduction.txt
+++ b/doc/introduction.txt
@@ -182,6 +182,7 @@ Here is the state of that vision as of December 3th, 2013 (after Theano release
   * Possible implementation note: allow Theano Variable in the fgraph to
     have more than 1 owner.
 
+* We support Python 2 and Python 3.
 * We have a CUDA backend for tensors of type `float32` only.
 * Efforts have begun towards a generic GPU ndarray (GPU tensor) (started in the
   `libgpuarray <https://github.com/Theano/libgpuarray>`_ project)

--- a/setup.py
+++ b/setup.py
@@ -160,7 +160,6 @@ def do_setup():
           url=URL,
           license=LICENSE,
           platforms=PLATFORMS,
-          use_2to3=True,
           packages=find_packages(),
           # 1.7.0 give too much warning related to numpy.diagonal.
           install_requires=['numpy>=1.7.1', 'scipy>=0.11', 'six>=1.9.0'],


### PR DESCRIPTION
Before I made changes, I ran [nose](https://nose.readthedocs.org/en/latest/) tests on this package to verify that it worked under Python 2 and Python 3. Theano includes many tests, and they're still running. The output looks the same under Python 2.7 and Python 3.4.

I believe this pull request (aka PR) can be merged into Theano, and I'll let you propose the PR since you noticed this issue. Also, they have [announced Python 3.3 support](https://groups.google.com/forum/#!topic/theano-announce/C6V74QHKmWQ) in Theano 0.6 -- it looks like their docs need a refresh.
